### PR TITLE
:herb: add in additional publishing metadata

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,5 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 
+lib/gemconfig.rb
 .github/workflows/publish.yml
 test/test_helper.rb
 test/test_vellum.rb

--- a/lib/gemconfig.rb
+++ b/lib/gemconfig.rb
@@ -3,12 +3,12 @@
 module Vellum
   module Gemconfig
     VERSION = ""
-    AUTHORS = [""].freeze
+    AUTHORS = ["Vellum"].freeze
     EMAIL = ""
-    SUMMARY = ""
-    DESCRIPTION = ""
-    HOMEPAGE = "https://github.com/REPO/URL"
-    SOURCE_CODE_URI = "https://github.com/REPO/URL"
-    CHANGELOG_URI = "https://github.com/REPO/URL/blob/master/CHANGELOG.md"
+    SUMMARY = "The Vellum Ruby Library provides access to the Vellum API from Ruby."
+    DESCRIPTION = "The Vellum Ruby Library provides access to the Vellum API from Ruby."
+    HOMEPAGE = "https://github.com/vellum-ai/vellum-client-ruby"
+    SOURCE_CODE_URI = "https://github.com/vellum-ai/vellum-client-ruby"
+    CHANGELOG_URI = "https://github.com/vellum-ai/vellum-client-ruby/blob/master/CHANGELOG.md"
   end
 end

--- a/vellum_ai.gemspec
+++ b/vellum_ai.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday-multipart", "~> 1.0"
   spec.add_dependency "faraday-retry", "~> 2.2"
   spec.add_dependency "mini_mime", "~> 1.1"
+  spec.licenses = ["MIT"]
 end


### PR DESCRIPTION
The gemconfig file is typically manually populated, so I went ahead and filled out additional information that would appear on the gem page